### PR TITLE
Improve analytics schema, privacy docs, and error telemetry

### DIFF
--- a/.cursor/plans/analytics_parity_0043edbb.plan.md
+++ b/.cursor/plans/analytics_parity_0043edbb.plan.md
@@ -1,0 +1,126 @@
+---
+name: analytics parity
+overview: Update the current Astro/PostHog browser analytics implementation so future events use the new canonical analytics schema, add wide-event-style success and failure properties, and enable PostHog browser error tracking. The backfill remains out of scope and will get a separate one-off Python plan under sandbox/ that transforms legacy rows into this new schema.
+todos:
+  - id: schema-contract
+    content: Define the typed product event and wide-event property contract in `src/utils/analytics.ts`.
+    status: pending
+  - id: posthog-errors
+    content: Update PostHog browser initialization to support exception autocapture and manual exception capture.
+    status: pending
+  - id: pdf-flow-events
+    content: Refactor PDF processing/download/print flows to emit parity success and failure events with duration/outcome/correlation fields.
+    status: pending
+  - id: build-context
+    content: Add safe public environment/build metadata to analytics context and env typings.
+    status: pending
+  - id: verify
+    content: Run typecheck/lint/build and verify representative PostHog product/error events.
+    status: pending
+isProject: false
+---
+
+# Analytics Parity and Error Tracking Plan
+
+## Scope
+- In scope: current/future browser product events, handled workflow failures, PostHog browser error tracking, event schema consistency, verification.
+- Out of scope: historical backfill from `postlabel_nextjs_prod_dump.sql`; that gets its own `sandbox/` Python plan later.
+- Privacy stance: preserve the site’s public promise that PDF contents, filenames, addresses, tracking numbers, user accounts, stable sessions, and user identification are not collected.
+
+## Current Shape
+- PostHog is loaded via [`src/components/analytics/PostHog.astro`](/Users/mneveroff/Code/postlabel/src/components/analytics/PostHog.astro) with `/ingest` proxying and explicit product events only.
+- The main workflow lives in [`src/utils/pdf-util.ts`](/Users/mneveroff/Code/postlabel/src/utils/pdf-util.ts), where processing/download/print success events already include most legacy fields.
+- [`src/utils/analytics.ts`](/Users/mneveroff/Code/postlabel/src/utils/analytics.ts) is the right place to centralize the event contract, exception capture wrapper, and shared wide-event metadata.
+
+## Event Contract
+Standardize product events around future-facing names and fields. Backfill will be reshaped to this schema later by a one-off Python script, so do not mirror legacy database columns or add compatibility aliases to live events.
+- `label_processing_completed`
+- `label_processing_failed`
+- `label_pdf_downloaded`
+- `label_pdf_download_failed`
+- `label_pdf_printed`
+- `label_pdf_print_failed`
+- Optional validation rejects as separate outcome events, e.g. `label_file_rejected`, only if we want visibility into non-PDF/too-large/too-many-file cases.
+
+Every workflow event should carry:
+- Aggregate count fields: `files_count`, `accepted_files_count`, `rejected_files_count`, `input_pages_count`, `output_pages_count`, and `labels_count`.
+- Flexible label-source fields:
+  - `label_source_counts`: object keyed by normalized source, e.g. `{ royal_mail_domestic: 2, royal_mail_international: 1, ebay: 0, parcel_force: 0, unknown: 0 }`.
+  - `label_sources_detected`: sorted array of source keys with count > 0, useful for simple filtering/breakdowns.
+  - `label_source_count_total`: sum of `label_source_counts`, expected to match `labels_count`.
+  - Do not emit provider-specific top-level fields like `rm_count`, `rm_international_count`, `ebay_count`, or `parcel_force_count`.
+- Privacy-adjusted size fields: replace exact `payload_size_bytes` with bucketed payload size properties such as `payload_size_bucket` and, if useful, `payload_size_mb_rounded`. Keep exact output PDF size out of events unless it is also bucketed.
+- Wide-event fields: `outcome`, `duration_ms`, `operation`, `page_path`, `source: "browser"`, safe app/version metadata when available, a per-page-load anonymous `page_context_id`, and a per-operation `event_id`/`trace_id`.
+- Failure fields when applicable: `error_type`, sanitized `error_code`/`failure_stage`, and the same aggregate counts known at the failure point. Avoid sending raw PDF-derived messages, filenames, label text, stack-local variables, or arbitrary error payloads as product event properties.
+
+Similar schema improvements:
+- Add `analytics_schema_version`, starting at `1`, so future event changes and backfills can coexist cleanly.
+- Split workflow operation from result: `operation` should be stable (`process_labels`, `download_pdf`, `print_pdf`, `validate_files`) and `outcome` should be one of `success`, `failure`, or `rejected`.
+- Use machine-readable reason fields for rejects/failures, e.g. `reject_reason: "non_pdf_file" | "file_too_large" | "too_many_files" | "payload_too_large" | "no_valid_files"` and `failure_stage: "read_file" | "parse_pdf" | "classify_label" | "render_label" | "compose_pdf" | "download_pdf" | "print_pdf"`.
+- Add `page_context_id` and `event_id` only as short-lived random IDs, never as user/session identities.
+- Use low-cardinality environment fields like `app_environment`, `app_version`, `commit_sha_short`, and `deploy_provider` when available; avoid full URLs, referrers, IP-derived fields, or browser fingerprint material.
+
+## Privacy Decisions
+- Use a balanced correlation model: create one random `page_context_id` per page load and one random `event_id`/`trace_id` per workflow operation. This links processing -> download/print/errors within the same loaded page, but resets on reload and does not identify users across visits.
+- Do not introduce accounts, `identify`, group analytics, stable browser fingerprints, localStorage persistence, cookies, or long-lived session IDs.
+- Keep PostHog `autocapture: false`, session replay disabled, and memory-only persistence.
+- Keep exact aggregate non-content counts because they are core product metrics and already disclosed in the legal copy.
+- Bucket payload sizes to reduce fingerprintability of unusual PDF batches while preserving trend usefulness.
+- Prefer normalized, low-cardinality keys for label sources instead of raw `LabelType` display strings. For example, map `RM` and `RM Mobile` to `royal_mail_domestic`, `RM International` and `RM International Mobile` to `royal_mail_international`, preserve `ebay`, `parcel_force`, and include `unknown`.
+- Treat PostHog error tracking as browser exception telemetry, not logging of PDF contents. Manual exception properties should be curated and sanitized; product failure events should carry the structured business context.
+
+## Implementation Steps
+1. Centralize analytics helpers in [`src/utils/analytics.ts`](/Users/mneveroff/Code/postlabel/src/utils/analytics.ts):
+   - Expand the `Window.posthog` type to include `captureException`, `startExceptionAutocapture`, and `register` if used.
+   - Add typed event/property unions so event names and outcome values stay type-safe.
+   - Add helpers for generating the per-page-load anonymous context ID, per-operation IDs, payload-size buckets, label-source counts, schema version, and shared non-sensitive context.
+   - Add `captureProductException(error, properties)` that calls `posthog.captureException(error, properties)` with curated fields only.
+
+2. Update PostHog initialization in [`src/components/analytics/PostHog.astro`](/Users/mneveroff/Code/postlabel/src/components/analytics/PostHog.astro):
+   - Use the newer snippet method list that includes `startExceptionAutocapture`.
+   - Keep `autocapture: false`, `capture_pageview: true`, `disable_session_recording: true`, and memory persistence.
+   - Do not call `identify`, enable person profiles, or register stable user/session identifiers.
+   - Set `person_profiles: "identified_only"` explicitly to keep anonymous events from creating person profiles.
+   - Add current PostHog JS defaults if compatible with this setup, e.g. `defaults: "2026-01-30"`.
+   - Enable documented browser exception capture with `capture_exceptions: { capture_unhandled_errors: true, capture_unhandled_rejections: true, capture_console_errors: false }` so unhandled errors and unhandled promise rejections become `$exception` events without capturing `console.error`.
+   - Use `captureException(error, properties)` for handled errors. Do not manually capture `$exception` events.
+   - Add a narrow `before_send` only if needed to drop known noisy exception types or to enforce a final exception-event allowlist. Avoid broad property deletion because SDK-reserved fields such as the project token must remain intact.
+
+3. Refactor [`src/utils/pdf-util.ts`](/Users/mneveroff/Code/postlabel/src/utils/pdf-util.ts) around operation-level wide events:
+   - Wrap processing, PDF generation for download, and PDF generation for print in `try/catch/finally`-style helpers.
+   - Capture success and failure with the same event contract, including duration and known counts.
+   - Replace fixed provider counts with `label_source_counts` and `label_sources_detected`.
+   - Track accepted/rejected file counts and reject reasons for validation exits that currently only show an alert.
+   - Use bucketed payload/output sizes instead of exact byte counts in new live events.
+   - Preserve current user-facing behavior, alerts, and privacy boundaries.
+   - For caught errors, send both the product failure event and `captureProductException` with the same `event_id`/`trace_id`.
+
+4. Add environment/build context:
+   - Extend [`src/env.d.ts`](/Users/mneveroff/Code/postlabel/src/env.d.ts) for public build metadata such as `PUBLIC_APP_VERSION` or `PUBLIC_VERCEL_GIT_COMMIT_SHA` if exposed by deployment.
+   - Include only non-sensitive metadata in event properties.
+
+5. Source maps and deploy readiness:
+   - PostHog recommends source maps for readable browser error stack traces.
+   - Prefer a follow-up source-map pass using the Vite-compatible PostHog Rollup plugin in Astro’s Vite config, or the PostHog CLI/GitHub Action after `pnpm build`.
+   - If uploading via the Vite/Rollup plugin, use build-only env vars such as `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID`, and `POSTHOG_HOST=https://eu.i.posthog.com`; do not expose the personal API key to client code.
+   - If uploading via CLI/GitHub Actions, use EU app host settings where required (`https://eu.posthog.com`) and keep the token in CI secrets.
+   - Ensure source maps improve stack traces without exposing PDF contents or runtime variables. Do not enable any option that captures local variables containing parsed PDF text.
+
+6. Update legal copy if needed:
+   - [`src/components/legal/PrivacyPage.tsx`](/Users/mneveroff/Code/postlabel/src/components/legal/PrivacyPage.tsx), [`src/components/legal/TldrPage.tsx`](/Users/mneveroff/Code/postlabel/src/components/legal/TldrPage.tsx), and [`src/components/legal/DataPage.tsx`](/Users/mneveroff/Code/postlabel/src/components/legal/DataPage.tsx) already disclose aggregate counts, sizes, timing, page context, no identification, no autocapture, and no replay.
+   - If browser exception capture is enabled, update the wording to disclose error telemetry in plain language: stack traces/error metadata may be sent to PostHog for debugging, without PDF contents, filenames, label text, addresses, or tracking numbers.
+
+7. Verification:
+   - Run `pnpm typecheck`, `pnpm lint`, and `pnpm build`.
+   - In a local preview, verify one processing success, one download, one print, one handled processing failure, and one thrown test exception appear in PostHog with matching page-load and operation correlation properties.
+   - Inspect the captured event payloads before considering the work done, confirming no filenames, PDF text, addresses, tracking numbers, raw exact payload bytes, stable IDs, or user-identifying properties are present.
+
+## OTel Note
+Because this app currently builds as static Astro output, there is no server request lifecycle to instrument with OTel middleware. Current PostHog docs point OTel support primarily at server/AI observability exporters and APM-style ingestion, not a browser-only static workflow. The immediate plan should use PostHog browser product events plus `$exception` events, carrying short-lived OTel-style correlation fields (`trace_id`, `span_id`/`event_id`) so future server-side or collector-based tracing can join cleanly without renaming events or introducing stable user/session tracking.
+
+## PostHog Docs Validation
+- Browser error tracking: validated against PostHog’s web error tracking and exception capture docs. Browser SDKs support automatic exception capture through `capture_exceptions`, including `window.onerror` and `window.onunhandledrejection`, and handled errors should use `captureException(error, additionalProperties)`.
+- Privacy configuration: validated against PostHog JavaScript SDK docs for anonymous events, person profiles, persistence, and session replay. `persistence: "memory"`, no `identify`, no group calls, `person_profiles: "identified_only"`, `autocapture: false`, and `disable_session_recording: true` match the privacy posture.
+- Source maps: validated against PostHog source map docs. Astro’s Vite/Rollup build can use the PostHog Rollup plugin, or a post-build CLI/GitHub Action upload. This requires private build/CI env vars and should not leak a personal API key to the browser.
+- Filtering/sampling: validated against PostHog’s `before_send` examples for exception suppression. Use it narrowly for `$exception` noise control, not as a generic sanitizer over all event properties.
+- OTel: validated as a future-facing note, not part of the immediate browser implementation. PostHog docs show OTel exporters mainly for server/AI observability contexts; this static Astro app should not add OTel runtime dependencies just for client product events.

--- a/.cursor/plans/legacy_backfill_0e1cb80c.plan.md
+++ b/.cursor/plans/legacy_backfill_0e1cb80c.plan.md
@@ -1,0 +1,91 @@
+---
+name: legacy backfill
+overview: Backfill legacy PostLabel usage rows from `sandbox/prod_events.csv` into PostHog by transforming each row into the new canonical analytics schema. The implementation should live under `sandbox/`, run as a deliberate one-off, and include dry-run validation before any API writes.
+todos:
+  - id: validate-csv
+    content: Implement strict CSV validation using the intended 12-column schema and dry-run summaries.
+    status: pending
+  - id: transform-events
+    content: Transform legacy rows into canonical schema events with source counts, unknown reconciliation, bucketed sizes, and deterministic metadata.
+    status: pending
+  - id: dry-run-output
+    content: Add dry-run sample output and aggregate checks before any API calls.
+    status: pending
+  - id: posthog-send
+    content: Add explicit `--send` ingestion path with batching, retries, and historical timestamps.
+    status: pending
+  - id: verify-backfill
+    content: Verify event counts, sample properties, and PostHog ingestion results after sending.
+    status: pending
+isProject: false
+---
+
+# Legacy Analytics Backfill Plan
+
+## Inputs and Validation
+- Source file: [`sandbox/prod_events.csv`](/Users/mneveroff/Code/postlabel/sandbox/prod_events.csv), derived from [`sandbox/postlabel_nextjs_prod_dump.sql`](/Users/mneveroff/Code/postlabel/sandbox/postlabel_nextjs_prod_dump.sql).
+- Current validation findings:
+  - 529 data rows.
+  - Header has a CSV typo: missing comma between `RMINum` and `EbayRMNum`. Rows are still parseable with the intended 12-column schema.
+  - Event type counts: `2` Process = 279, `3` Download = 123, `4` Print = 127.
+  - Date range: `2024-01-25 19:11:03.73` to `2026-06-05 11:34:13.177`.
+  - No negative numeric values found.
+  - 83 rows have `labelsNum` greater than known source counts; treat the difference as `unknown` labels.
+
+## Implementation Shape
+Create a one-off script under [`sandbox/`](/Users/mneveroff/Code/postlabel/sandbox/) that:
+- Reads `prod_events.csv` with an explicit column list, ignoring the malformed header.
+- Validates row widths, UUIDs, timestamps, integer columns, and allowed event types before any network calls.
+- Emits a dry-run summary and sample transformed events by default.
+- Requires an explicit flag such as `--send` before calling PostHog.
+- Supports idempotency using `legacy_event_id` and a deterministic `uuid`/`event_id` derived from the legacy row ID.
+
+## Transform Rules
+Map legacy event types to new event names:
+- `2` -> `label_processing_completed`, `operation: "process_labels"`, `outcome: "success"`.
+- `3` -> `label_pdf_downloaded`, `operation: "download_pdf"`, `outcome: "success"`.
+- `4` -> `label_pdf_printed`, `operation: "print_pdf"`, `outcome: "success"`.
+
+Map legacy fields to the new schema:
+- `filesNum` -> `files_count` and `accepted_files_count`.
+- `pagesNum` -> `input_pages_count` for processing events; for download/print, use as `output_pages_count` if that better matches current live schema once implemented.
+- `labelsNum` -> `labels_count`.
+- `payloadSize` -> bucketed `payload_size_bucket` and optional rounded `payload_size_mb_rounded`; do not send exact bytes.
+- `pageHash` -> `legacy_page_hash` only if needed for audit/debug, or better omit from PostHog properties and use it only locally to derive a non-stable `page_context_id`.
+- `createdAt` -> PostHog event `timestamp`.
+- `id` -> `legacy_event_id` plus deterministic `event_id`/`trace_id`.
+
+Build flexible source counts:
+- `RMNum` -> `label_source_counts.royal_mail_domestic`.
+- `RMINum` -> `label_source_counts.royal_mail_international`.
+- `EbayRMNum` -> `label_source_counts.ebay`.
+- `PFNum` -> `label_source_counts.parcel_force`.
+- `unknown` -> `max(labelsNum - known_source_total, 0)`.
+- `label_sources_detected` -> sorted non-zero source keys.
+- `label_source_count_total` -> sum of all source counts, expected to equal `labels_count` after adding `unknown`.
+
+Add backfill metadata:
+- `analytics_schema_version: 1`.
+- `source: "legacy_postgres_backfill"`.
+- `backfill_batch_id` supplied by CLI arg or generated once per run.
+- `app_environment: "production"`.
+- No filenames, PDF text, addresses, tracking numbers, user identifiers, stable session IDs, or raw exact payload bytes.
+
+## PostHog Ingestion
+- Use PostHog capture API with historical timestamps and the existing EU host/project key.
+- Prefer a dry-run-first workflow that prints transformed JSONL samples and aggregate counts.
+- Send in small batches with retry/backoff and clear logging of successes/failures.
+- Keep a local report file in `sandbox/` only if explicitly requested during implementation; otherwise print the summary.
+
+## Verification
+- Validate the transformed event count equals 529 before sending.
+- Validate transformed event counts by name match the legacy type counts.
+- Validate every event has `analytics_schema_version`, `operation`, `outcome`, `label_source_counts`, `label_sources_detected`, `label_source_count_total`, bucketed payload size, and historical timestamp.
+- Validate `label_source_count_total === labels_count` after applying `unknown`.
+- After sending, query PostHog or inspect the activity feed for a small sample by `legacy_event_id` and verify historical dates and properties look correct.
+
+## Guardrails
+- Never mutate the source CSV during ingestion; if a cleaned CSV is useful, generate it as a separate explicit artifact.
+- Never use the malformed CSV header as the source of truth.
+- Never send raw `payloadSize` as exact bytes.
+- Never call `identify`, create person profiles intentionally, or backfill stable user/session identity.

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@
 PUBLIC_POSTHOG_KEY=
 # Optional: PostHog app UI host for toolbar links (defaults to EU)
 # PUBLIC_POSTHOG_UI_HOST=https://eu.posthog.com
+
+# Optional: non-sensitive build metadata attached to analytics events
+# PUBLIC_APP_ENVIRONMENT=development
+# PUBLIC_APP_VERSION=0.1.0
+# PUBLIC_DEPLOY_PROVIDER=vercel
+# PUBLIC_VERCEL_GIT_COMMIT_SHA=

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 .editorconfig
 .env
 .vercel
+sandbox

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PostLabel is a small static web tool that lets you convert Royal Mail, ParcelFor
 
 🖨️ See it live and print some labels: [PostLabel](https://postlabel.neveroff.dev/)
 
-The live site does not collect or store PDF contents. Aggregate product analytics (counts and sizes only) may be collected via PostHog.
+The live site does not collect or store PDF contents. Aggregate product analytics and browser error telemetry may be collected via PostHog without filenames, label text, addresses, tracking numbers, or PDF contents.
 
 ## Getting Started
 
@@ -16,13 +16,21 @@ If you want to run PostLabel on your own machine:
 4. Optionally copy `.env.example` to `.env` and set `PUBLIC_POSTHOG_KEY` for analytics (events are proxied via `/ingest` on your domain).
 5. Run `pnpm dev` to start the development server.
 
+## Environment Variables
+
+Only `PUBLIC_` variables are exposed to the browser. Do not put private PostHog API keys in these values.
+
+- `PUBLIC_POSTHOG_KEY` — optional publishable PostHog browser key.
+- `PUBLIC_POSTHOG_UI_HOST` — optional PostHog app host for UI links, defaults to `https://eu.posthog.com`.
+- `PUBLIC_APP_ENVIRONMENT`, `PUBLIC_APP_VERSION`, `PUBLIC_DEPLOY_PROVIDER`, `PUBLIC_VERCEL_GIT_COMMIT_SHA` — optional non-sensitive build metadata attached to analytics events.
+
 ## Scripts
 
 - `pnpm dev` — start Astro dev server
-- `pnpm build` — typecheck and build static site
+- `pnpm build` — build static site
 - `pnpm preview` — preview production build locally
 - `pnpm typecheck` — run Astro type checking
-- `pnpm lint` — run Oxlint on source files
+- `pnpm lint` — run Oxlint and `tsc --noEmit`
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "lint": "oxlint",
+    "lint": "oxlint && tsc --noEmit",
     "lint:fix": "oxlint --fix",
     "typecheck": "astro check"
   },

--- a/src/components/analytics/PostHog.astro
+++ b/src/components/analytics/PostHog.astro
@@ -33,7 +33,7 @@ const posthogSnippet = posthogKey
             return u.toString(1) + '.people (stub)';
           },
           o =
-            'init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug'.split(
+            'init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException startExceptionAutocapture loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug'.split(
               ' '
             ),
           n = 0;
@@ -50,7 +50,14 @@ posthog.init(${JSON.stringify(posthogKey)}, {
   ui_host: ${JSON.stringify(posthogUiHost)},
   autocapture: false,
   capture_pageview: true,
+  capture_exceptions: {
+    capture_unhandled_errors: true,
+    capture_unhandled_rejections: true,
+    capture_console_errors: false,
+  },
+  defaults: '2026-01-30',
   disable_session_recording: true,
+  person_profiles: 'identified_only',
   persistence: 'memory',
 });`
   : '';

--- a/src/components/legal/DataPage.tsx
+++ b/src/components/legal/DataPage.tsx
@@ -32,9 +32,11 @@ export default function DataPage() {
         client-side without sending PDF data externally.
       </p>
       <p>
-        PostHog receives aggregate product events (counts, sizes, timing) when you process, download,
-        or print labels. It does not receive filenames, label text, addresses, or tracking numbers.
-        PostHog is configured without autocapture, session replay, or user identification.
+        PostHog receives aggregate product events (counts, size buckets, timing) when you process,
+        download, or print labels. It also receives browser error telemetry for debugging, such as
+        stack traces and error metadata. It does not receive filenames, label text, addresses,
+        tracking numbers, or PDF contents. PostHog is configured without autocapture, session replay,
+        or user identification.
       </p>
       <p>
         Please refer to the privacy policies of{' '}

--- a/src/components/legal/PrivacyPage.tsx
+++ b/src/components/legal/PrivacyPage.tsx
@@ -26,7 +26,9 @@ export default function PrivacyPage() {
         The Service employs Cloudflare Cookieless Logging, Vercel Cookieless Analytics, Plausible
         Cookieless Analytics, and PostHog product analytics. PostHog events are triggered during
         Processing, Downloading, and Printing. They contain only aggregate counts (files, pages,
-        labels, label types), payload sizes, timing, and page context — never filenames, label text,
+        labels, label types), size buckets, timing, and page context — never filenames, label text,
+        addresses, or tracking numbers. PostHog also receives browser error telemetry for debugging,
+        such as stack traces and error metadata, without PDF contents, filenames, label text,
         addresses, or tracking numbers. PostHog is configured without autocapture or session replay.
       </p>
 

--- a/src/components/legal/TldrPage.tsx
+++ b/src/components/legal/TldrPage.tsx
@@ -36,9 +36,10 @@ export default function TldrPage() {
       </p>
       <p>
         We capture aggregate product analytics via PostHog when labels are processed, downloaded, or
-        printed. These events include counts (files, pages, labels, label types), payload sizes, and
+        printed. These events include counts (files, pages, labels, label types), size buckets, and
         timing — never filenames, label text, addresses, tracking numbers, or PDF contents. PostHog
-        may also receive standard browser transport metadata (such as page path and user agent).
+        may also receive standard browser transport metadata (such as page path and user agent) and
+        browser error telemetry for debugging, such as stack traces and error metadata.
       </p>
       <p>
         Go to <a href="/legal/privacy">Privacy Policy</a> for more details.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,6 +3,10 @@
 interface ImportMetaEnv {
   readonly PUBLIC_POSTHOG_KEY?: string;
   readonly PUBLIC_POSTHOG_UI_HOST?: string;
+  readonly PUBLIC_APP_ENVIRONMENT?: string;
+  readonly PUBLIC_APP_VERSION?: string;
+  readonly PUBLIC_DEPLOY_PROVIDER?: string;
+  readonly PUBLIC_VERCEL_GIT_COMMIT_SHA?: string;
 }
 
 interface ImportMeta {

--- a/src/models/Label.ts
+++ b/src/models/Label.ts
@@ -1,4 +1,4 @@
-import type { PDFPageProxy, TextContent } from 'pdfjs-dist';
+import type { PDFPageProxy } from 'pdfjs-dist';
 
 export interface InformedCanvas extends HTMLCanvasElement {
     // Add your custom properties and methods here
@@ -6,6 +6,7 @@ export interface InformedCanvas extends HTMLCanvasElement {
 }
 
 type LabelCoordinates = { x: number; y: number; width: number; height: number };
+type PdfTextContent = Awaited<ReturnType<PDFPageProxy['getTextContent']>>;
 export enum LabelType {
     RM = 'RM',
     RMMobile = 'RM Mobile',
@@ -21,7 +22,7 @@ export interface LabelData {
     name?: LabelType;
     pdfScale?: number;
     coordinates?: LabelCoordinates;
-    content?: TextContent;
+    content?: PdfTextContent;
 }
 
 export class SegmentInformation {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,35 +1,290 @@
 declare global {
   interface Window {
     posthog?: {
-      capture: (event: string, properties?: Record<string, unknown>) => void;
+      capture: (event: ProductEventName, properties?: Record<string, unknown>) => void;
+      captureException?: (error: Error, properties?: Record<string, unknown>) => void;
     };
   }
 }
 
-export type LabelProcessingProperties = {
-  files_count: number;
-  pages_count: number;
-  labels_count: number;
-  payload_size_bytes: number;
-  rm_count: number;
-  rm_international_count: number;
-  ebay_count: number;
-  parcel_force_count: number;
-  duration_ms?: number;
-  outcome: 'success' | 'failure';
-  page_path?: string;
+export const analyticsSchemaVersion = 1;
+
+export type ProductEventName =
+  | 'label_processing_completed'
+  | 'label_processing_failed'
+  | 'label_pdf_downloaded'
+  | 'label_pdf_download_failed'
+  | 'label_pdf_printed'
+  | 'label_pdf_print_failed'
+  | 'label_file_rejected';
+
+export type ProductOperation = 'process_labels' | 'download_pdf' | 'print_pdf' | 'validate_files';
+
+export type ProductOutcome = 'success' | 'failure' | 'rejected';
+
+export type RejectReason =
+  | 'non_pdf_file'
+  | 'file_too_large'
+  | 'too_many_files'
+  | 'payload_too_large'
+  | 'no_valid_files';
+
+export type FailureStage =
+  | 'read_file'
+  | 'parse_pdf'
+  | 'classify_label'
+  | 'render_label'
+  | 'compose_pdf'
+  | 'download_pdf'
+  | 'print_pdf';
+
+export type LabelSourceKey =
+  | 'royal_mail_domestic'
+  | 'royal_mail_international'
+  | 'ebay'
+  | 'parcel_force'
+  | 'unknown';
+
+export type LabelSourceCounts = Record<LabelSourceKey, number>;
+
+export type SizeBucket =
+  | '0_bytes'
+  | 'under_100kb'
+  | '100kb_to_500kb'
+  | '500kb_to_1mb'
+  | '1mb_to_5mb'
+  | 'over_5mb';
+
+export type OperationContext = {
+  event_id: string;
+  trace_id: string;
+  startedAt: number;
 };
 
+export type ProductEventProperties = {
+  operation: ProductOperation;
+  outcome: ProductOutcome;
+  files_count: number;
+  accepted_files_count: number;
+  rejected_files_count: number;
+  input_pages_count: number;
+  output_pages_count: number;
+  labels_count: number;
+  label_source_counts: LabelSourceCounts;
+  label_sources_detected: LabelSourceKey[];
+  label_source_count_total: number;
+  payload_size_bucket: SizeBucket;
+  payload_size_mb_rounded: number;
+  output_size_bucket?: SizeBucket;
+  output_size_mb_rounded?: number;
+  duration_ms: number;
+  event_id: string;
+  trace_id: string;
+  page_path?: string;
+  reject_reason?: RejectReason;
+  error_type?: string;
+  error_code?: string;
+  failure_stage?: FailureStage;
+};
+
+export type ProductExceptionProperties = Pick<
+  ProductEventProperties,
+  | 'operation'
+  | 'outcome'
+  | 'event_id'
+  | 'trace_id'
+  | 'duration_ms'
+  | 'failure_stage'
+  | 'error_type'
+  | 'error_code'
+>;
+
+const labelSourceKeys: LabelSourceKey[] = [
+  'royal_mail_domestic',
+  'royal_mail_international',
+  'ebay',
+  'parcel_force',
+  'unknown',
+];
+
+let pageContextId: string | undefined;
+
+function getPageContextId(): string {
+  pageContextId ??= createShortId();
+  return pageContextId;
+}
+
+function createShortId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID().replaceAll('-', '').slice(0, 16);
+  }
+
+  return Math.random().toString(36).slice(2, 18).padEnd(16, '0');
+}
+
+function sanitizeCode(value: unknown): string | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return undefined;
+  }
+
+  return String(value).replaceAll(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || undefined;
+}
+
+function removeUndefinedProperties(properties: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined)
+  );
+}
+
+function getSharedAnalyticsProperties(properties: { page_path?: string }) {
+  const commitSha = import.meta.env.PUBLIC_VERCEL_GIT_COMMIT_SHA;
+
+  return removeUndefinedProperties({
+    analytics_schema_version: analyticsSchemaVersion,
+    page_context_id: getPageContextId(),
+    page_path:
+      properties.page_path ??
+      (typeof window === 'undefined' ? undefined : window.location.pathname),
+    source: 'browser',
+    app_environment: import.meta.env.PUBLIC_APP_ENVIRONMENT ?? import.meta.env.MODE,
+    app_version: import.meta.env.PUBLIC_APP_VERSION,
+    commit_sha_short: commitSha?.slice(0, 12),
+    deploy_provider: import.meta.env.PUBLIC_DEPLOY_PROVIDER ?? (commitSha ? 'vercel' : undefined),
+  });
+}
+
+export function createOperationContext(): OperationContext {
+  return {
+    event_id: createShortId(),
+    trace_id: createShortId(),
+    startedAt: performance.now(),
+  };
+}
+
+export function getOperationDurationMs(context: OperationContext): number {
+  return Math.round(performance.now() - context.startedAt);
+}
+
+export function getEmptyLabelSourceCounts(): LabelSourceCounts {
+  return {
+    royal_mail_domestic: 0,
+    royal_mail_international: 0,
+    ebay: 0,
+    parcel_force: 0,
+    unknown: 0,
+  };
+}
+
+export function normalizeLabelSource(labelType: string | undefined): LabelSourceKey {
+  switch (labelType) {
+    case 'RM':
+    case 'RM Mobile':
+      return 'royal_mail_domestic';
+    case 'RM International':
+    case 'RM International Mobile':
+      return 'royal_mail_international';
+    case 'Ebay':
+      return 'ebay';
+    case 'ParcelForce':
+      return 'parcel_force';
+    default:
+      return 'unknown';
+  }
+}
+
+export function buildLabelSourceCounts(labelTypes: readonly (string | undefined)[]): LabelSourceCounts {
+  const counts = getEmptyLabelSourceCounts();
+
+  for (const labelType of labelTypes) {
+    counts[normalizeLabelSource(labelType)] += 1;
+  }
+
+  return counts;
+}
+
+export function getDetectedLabelSources(counts: LabelSourceCounts): LabelSourceKey[] {
+  return labelSourceKeys.filter((source) => counts[source] > 0);
+}
+
+export function getLabelSourceCountTotal(counts: LabelSourceCounts): number {
+  return labelSourceKeys.reduce((total, source) => total + counts[source], 0);
+}
+
+export function getSizeBucket(sizeBytes: number): SizeBucket {
+  if (sizeBytes <= 0) {
+    return '0_bytes';
+  }
+
+  if (sizeBytes < 100_000) {
+    return 'under_100kb';
+  }
+
+  if (sizeBytes < 500_000) {
+    return '100kb_to_500kb';
+  }
+
+  if (sizeBytes < 1_000_000) {
+    return '500kb_to_1mb';
+  }
+
+  if (sizeBytes <= 5_000_000) {
+    return '1mb_to_5mb';
+  }
+
+  return 'over_5mb';
+}
+
+export function getSizeMbRounded(sizeBytes: number): number {
+  return Math.round((sizeBytes / 1_000_000) * 2) / 2;
+}
+
+export function getErrorType(error: unknown): string {
+  if (error instanceof Error && error.name) {
+    return sanitizeCode(error.name) ?? 'Error';
+  }
+
+  return typeof error;
+}
+
+export function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return undefined;
+  }
+
+  return sanitizeCode((error as { code?: unknown }).code);
+}
+
 export function captureProductEvent(
-  event: string,
-  properties: LabelProcessingProperties | Record<string, unknown>
+  event: ProductEventName,
+  properties: ProductEventProperties
 ): void {
   if (typeof window === 'undefined' || !window.posthog) {
     return;
   }
 
   window.posthog.capture(event, {
+    ...getSharedAnalyticsProperties(properties),
     ...properties,
-    page_path: properties.page_path ?? window.location.pathname,
   });
+}
+
+export function captureProductException(
+  error: unknown,
+  properties: ProductExceptionProperties
+): void {
+  if (typeof window === 'undefined' || !window.posthog?.captureException) {
+    return;
+  }
+
+  const safeError = error instanceof Error ? error : new Error('Non-Error exception');
+
+  window.posthog.captureException(
+    safeError,
+    removeUndefinedProperties({
+      ...getSharedAnalyticsProperties({}),
+      ...properties,
+      analytics_schema_version: analyticsSchemaVersion,
+      source: 'browser',
+    })
+  );
 }

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -276,7 +276,8 @@ export function captureProductException(
     return;
   }
 
-  const safeError = error instanceof Error ? error : new Error('Non-Error exception');
+  const safeError = new Error('PDF workflow failed');
+  safeError.name = 'PostLabelHandledWorkflowError';
 
   window.posthog.captureException(
     safeError,

--- a/src/utils/pdf-util.ts
+++ b/src/utils/pdf-util.ts
@@ -1,11 +1,31 @@
-import { useState, useRef } from 'react';
+import { useRef, useState } from 'react';
 import fileSaver from 'file-saver';
 import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist';
 import { jsPDF } from 'jspdf';
 
-import { Label, SegmentInformation, LabelType } from '@/models/Label';
+import { Label, SegmentInformation } from '@/models/Label';
 import type { InformedCanvas } from '@/models/Label';
-import { captureProductEvent, type LabelProcessingProperties } from '@/utils/analytics';
+import {
+  buildLabelSourceCounts,
+  captureProductEvent,
+  captureProductException,
+  createOperationContext,
+  getDetectedLabelSources,
+  getEmptyLabelSourceCounts,
+  getErrorCode,
+  getErrorType,
+  getLabelSourceCountTotal,
+  getOperationDurationMs,
+  getSizeBucket,
+  getSizeMbRounded,
+  type FailureStage,
+  type OperationContext,
+  type ProductEventName,
+  type ProductEventProperties,
+  type ProductOperation,
+  type ProductOutcome,
+  type RejectReason,
+} from '@/utils/analytics';
 
 const { saveAs } = fileSaver;
 
@@ -21,6 +41,26 @@ const outputLabelHeight = 383.5;
 const outputFormat = 'image/jpeg';
 const outputQuality = 0.8;
 
+type ProcessingSnapshot = {
+  filesCount: number;
+  acceptedFilesCount: number;
+  rejectedFilesCount: number;
+  inputPagesCount: number;
+  payloadSizeBytes: number;
+};
+
+type WorkflowError = Error & {
+  failureStage?: FailureStage;
+};
+
+const emptyProcessingSnapshot: ProcessingSnapshot = {
+  filesCount: 0,
+  acceptedFilesCount: 0,
+  rejectedFilesCount: 0,
+  inputPagesCount: 0,
+  payloadSizeBytes: 0,
+};
+
 function getCurrentDateTimeFormatted(): string {
   const currentDate = new Date();
 
@@ -34,37 +74,122 @@ function getCurrentDateTimeFormatted(): string {
   return `${year}${month}${day}-${hours}${minutes}${seconds}`;
 }
 
-function countLabelTypes(labels: InformedCanvas[]) {
+function toWorkflowError(error: unknown, failureStage: FailureStage): WorkflowError {
+  if (error instanceof Error) {
+    const workflowError = error as WorkflowError;
+    workflowError.failureStage ??= failureStage;
+    return workflowError;
+  }
+
+  const workflowError = new Error('PDF workflow failed') as WorkflowError;
+  workflowError.failureStage = failureStage;
+  return workflowError;
+}
+
+async function runWorkflowStep<T>(
+  failureStage: FailureStage,
+  action: () => Promise<T>
+): Promise<T> {
+  try {
+    return await action();
+  } catch (error) {
+    throw toWorkflowError(error, failureStage);
+  }
+}
+
+function getFailureStage(error: unknown, fallback: FailureStage): FailureStage {
+  if (error instanceof Error && 'failureStage' in error) {
+    return (error as WorkflowError).failureStage ?? fallback;
+  }
+
+  return fallback;
+}
+
+function buildWorkflowProperties({
+  context,
+  durationMs,
+  labels,
+  operation,
+  outcome,
+  snapshot,
+  outputPagesCount,
+  outputSizeBytes,
+  rejectReason,
+  failureStage,
+  error,
+}: {
+  context: OperationContext;
+  durationMs: number;
+  labels: InformedCanvas[];
+  operation: ProductOperation;
+  outcome: ProductOutcome;
+  snapshot: ProcessingSnapshot;
+  outputPagesCount: number;
+  outputSizeBytes?: number;
+  rejectReason?: RejectReason;
+  failureStage?: FailureStage;
+  error?: unknown;
+}): ProductEventProperties {
+  const labelSourceCounts = labels.length
+    ? buildLabelSourceCounts(labels.map((label) => label.labelType))
+    : getEmptyLabelSourceCounts();
+
   return {
-    rm_count: labels.filter(
-      (page) => page.labelType === LabelType.RM || page.labelType === LabelType.RMMobile
-    ).length,
-    rm_international_count: labels.filter(
-      (page) =>
-        page.labelType === LabelType.RMInternational ||
-        page.labelType === LabelType.RMInternationalMobile
-    ).length,
-    ebay_count: labels.filter((page) => page.labelType === LabelType.Ebay).length,
-    parcel_force_count: labels.filter((page) => page.labelType === LabelType.ParcelForce).length,
+    operation,
+    outcome,
+    files_count: snapshot.filesCount,
+    accepted_files_count: snapshot.acceptedFilesCount,
+    rejected_files_count: snapshot.rejectedFilesCount,
+    input_pages_count: snapshot.inputPagesCount,
+    output_pages_count: outputPagesCount,
+    labels_count: labels.length,
+    label_source_counts: labelSourceCounts,
+    label_sources_detected: getDetectedLabelSources(labelSourceCounts),
+    label_source_count_total: getLabelSourceCountTotal(labelSourceCounts),
+    payload_size_bucket: getSizeBucket(snapshot.payloadSizeBytes),
+    payload_size_mb_rounded: getSizeMbRounded(snapshot.payloadSizeBytes),
+    output_size_bucket: outputSizeBytes === undefined ? undefined : getSizeBucket(outputSizeBytes),
+    output_size_mb_rounded:
+      outputSizeBytes === undefined ? undefined : getSizeMbRounded(outputSizeBytes),
+    duration_ms: durationMs,
+    event_id: context.event_id,
+    trace_id: context.trace_id,
+    reject_reason: rejectReason,
+    failure_stage: failureStage,
+    error_type: error === undefined ? undefined : getErrorType(error),
+    error_code: error === undefined ? undefined : getErrorCode(error),
   };
 }
 
-function buildProcessingProperties(
-  labels: InformedCanvas[],
-  filesCount: number,
-  pagesCount: number,
-  payloadSizeBytes: number,
-  durationMs: number,
-  outcome: 'success' | 'failure'
-): LabelProcessingProperties {
+function captureWorkflowFailure(
+  eventName: ProductEventName,
+  properties: ProductEventProperties,
+  error: unknown
+): void {
+  captureProductEvent(eventName, properties);
+  captureProductException(error, {
+    operation: properties.operation,
+    outcome: properties.outcome,
+    event_id: properties.event_id,
+    trace_id: properties.trace_id,
+    duration_ms: properties.duration_ms,
+    failure_stage: properties.failure_stage,
+    error_type: properties.error_type,
+    error_code: properties.error_code,
+  });
+}
+
+function buildValidationSnapshot(
+  files: File[],
+  rejectedFilesCount: number,
+  payloadSizeBytes: number
+): ProcessingSnapshot {
   return {
-    files_count: filesCount,
-    pages_count: pagesCount,
-    labels_count: labels.length,
-    payload_size_bytes: payloadSizeBytes,
-    duration_ms: durationMs,
-    outcome,
-    ...countLabelTypes(labels),
+    filesCount: files.length,
+    acceptedFilesCount: 0,
+    rejectedFilesCount,
+    inputPagesCount: 0,
+    payloadSizeBytes,
   };
 }
 
@@ -73,10 +198,12 @@ export function usePDFHandler() {
   const [pdfPages, setPdfPages] = useState<InformedCanvas[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const lastProcessingSnapshotRef = useRef<ProcessingSnapshot>(emptyProcessingSnapshot);
 
   const clearPdfPages = () => {
     setPdfPages([]);
     setSelectedFiles(null);
+    lastProcessingSnapshotRef.current = emptyProcessingSnapshot;
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
@@ -84,17 +211,36 @@ export function usePDFHandler() {
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsLoading(true);
-    const startedAt = performance.now();
+    const context = createOperationContext();
     const files = e.target.files ? Array.from(e.target.files) : [];
+    const totalSize = files.reduce((total, file) => total + file.size, 0);
+
+    const captureValidationReject = (rejectReason: RejectReason, rejectedFilesCount: number) => {
+      captureProductEvent(
+        'label_file_rejected',
+        buildWorkflowProperties({
+          context,
+          durationMs: getOperationDurationMs(context),
+          labels: [],
+          operation: 'validate_files',
+          outcome: 'rejected',
+          snapshot: buildValidationSnapshot(files, rejectedFilesCount, totalSize),
+          outputPagesCount: 0,
+          rejectReason,
+        })
+      );
+    };
 
     const nonPdfFiles = files.filter((file) => file.type !== 'application/pdf');
     if (nonPdfFiles.length > 0) {
+      captureValidationReject('non_pdf_file', nonPdfFiles.length);
       alert('Some files were not uploaded because they are not PDFs.');
       setIsLoading(false);
       return;
     }
 
     if (files.length > 100) {
+      captureValidationReject('too_many_files', files.length);
       alert('You cannot upload more than 100 files at once.');
       setIsLoading(false);
       return;
@@ -102,13 +248,14 @@ export function usePDFHandler() {
 
     const largeFiles = files.filter((file) => file.size > 1000000);
     if (largeFiles.length > 0) {
+      captureValidationReject('file_too_large', largeFiles.length);
       alert('Some files were not uploaded because they exceed the 1MB size limit.');
       setIsLoading(false);
       return;
     }
 
-    const totalSize = files.reduce((total, file) => total + file.size, 0);
     if (totalSize > 5000000) {
+      captureValidationReject('payload_too_large', files.length);
       alert('The total size of all files exceeds the 5MB limit.');
       setIsLoading(false);
       return;
@@ -118,9 +265,10 @@ export function usePDFHandler() {
       (file) => file.type === 'application/pdf' && file.size <= 1000000
     );
 
-    const payloadSize = validFiles.reduce((total, file) => total + file.size, 0);
+    const payloadSizeBytes = validFiles.reduce((total, file) => total + file.size, 0);
 
     if (validFiles.length === 0) {
+      captureValidationReject('no_valid_files', files.length);
       clearPdfPages();
       setIsLoading(false);
       alert('There were no valid files selected.');
@@ -128,57 +276,87 @@ export function usePDFHandler() {
     }
 
     setSelectedFiles(validFiles as unknown as FileList);
+    lastProcessingSnapshotRef.current = {
+      filesCount: files.length,
+      acceptedFilesCount: validFiles.length,
+      rejectedFilesCount: files.length - validFiles.length,
+      inputPagesCount: 0,
+      payloadSizeBytes,
+    };
 
     try {
-      await handleFileProcessing(validFiles as unknown as FileList, payloadSize, startedAt);
-    } catch {
-      captureProductEvent('label_processing_failed', {
-        files_count: validFiles.length,
-        pages_count: 0,
-        labels_count: 0,
-        payload_size_bytes: payloadSize,
-        rm_count: 0,
-        rm_international_count: 0,
-        ebay_count: 0,
-        parcel_force_count: 0,
-        duration_ms: Math.round(performance.now() - startedAt),
-        outcome: 'failure',
-      });
+      await handleFileProcessing(validFiles, payloadSizeBytes, context);
+    } catch (error) {
+      const durationMs = getOperationDurationMs(context);
+      const snapshot = lastProcessingSnapshotRef.current;
+
+      captureWorkflowFailure(
+        'label_processing_failed',
+        buildWorkflowProperties({
+          context,
+          durationMs,
+          labels: [],
+          operation: 'process_labels',
+          outcome: 'failure',
+          snapshot,
+          outputPagesCount: 0,
+          failureStage: getFailureStage(error, 'parse_pdf'),
+          error,
+        }),
+        error
+      );
+    } finally {
       setIsLoading(false);
     }
   };
 
   const handleFileProcessing = async (
-    passedFiles: FileList,
-    payloadSize: number,
-    startedAt: number
+    validFiles: File[],
+    payloadSizeBytes: number,
+    context: OperationContext
   ) => {
     let allPages = 0;
 
-    const validFiles = Array.from(passedFiles || []).filter(
-      (file) => file.type === 'application/pdf' && file.size <= 1000000
-    );
-
     const allLabels = await Promise.all(
-      Array.from(passedFiles || []).map(async (file: File) => {
-        const fileReader = new FileReader();
+      validFiles.map(async (file: File) => {
         const labels: InformedCanvas[] = [];
 
-        fileReader.readAsArrayBuffer(file);
-        const result = await new Promise<ArrayBuffer>((resolve) => {
-          fileReader.onload = () => resolve(fileReader.result as ArrayBuffer);
+        const result = await runWorkflowStep('read_file', async () => {
+          const fileReader = new FileReader();
+
+          return await new Promise<ArrayBuffer>((resolve, reject) => {
+            fileReader.onload = () => resolve(fileReader.result as ArrayBuffer);
+            fileReader.onerror = () => reject(fileReader.error ?? new Error('File read failed'));
+            fileReader.readAsArrayBuffer(file);
+          });
         });
 
-        const pdf = await getDocument({ data: new Uint8Array(result) }).promise;
+        const pdf = await runWorkflowStep(
+          'parse_pdf',
+          async () => await getDocument({ data: new Uint8Array(result) }).promise
+        );
         const numPages = pdf.numPages;
         allPages += numPages;
+        lastProcessingSnapshotRef.current = {
+          ...lastProcessingSnapshotRef.current,
+          inputPagesCount: allPages,
+        };
 
         for (let i = 1; i <= numPages; i++) {
-          const page = await pdf.getPage(i);
-          const content = await page.getTextContent();
+          const page = await runWorkflowStep('parse_pdf', async () => await pdf.getPage(i));
+          const content = await runWorkflowStep(
+            'classify_label',
+            async () => await page.getTextContent()
+          );
 
-          const label = new Label({ content });
-          const newPages = await label.getPages(document, page);
+          const label = await runWorkflowStep(
+            'classify_label',
+            async () => new Label({ content })
+          );
+          const newPages = await runWorkflowStep(
+            'render_label',
+            async () => await label.getPages(document, page)
+          );
 
           for (const newPage of newPages.pages) {
             labels.push(newPage);
@@ -190,21 +368,29 @@ export function usePDFHandler() {
     );
 
     const flatLabels = allLabels.flat();
+    const snapshot: ProcessingSnapshot = {
+      filesCount: validFiles.length,
+      acceptedFilesCount: validFiles.length,
+      rejectedFilesCount: 0,
+      inputPagesCount: allPages,
+      payloadSizeBytes,
+    };
 
     captureProductEvent(
       'label_processing_completed',
-      buildProcessingProperties(
-        flatLabels,
-        validFiles.length,
-        allPages,
-        payloadSize,
-        Math.round(performance.now() - startedAt),
-        'success'
-      )
+      buildWorkflowProperties({
+        context,
+        durationMs: getOperationDurationMs(context),
+        labels: flatLabels,
+        operation: 'process_labels',
+        outcome: 'success',
+        snapshot,
+        outputPagesCount: flatLabels.length,
+      })
     );
 
+    lastProcessingSnapshotRef.current = snapshot;
     setPdfPages(flatLabels);
-    setIsLoading(false);
   };
 
   async function preparePDF(labels: InformedCanvas[], hasMargin: boolean) {
@@ -293,52 +479,105 @@ export function usePDFHandler() {
   }
 
   const handleFilePrinting = async (hasMargin: boolean) => {
-    const startedAt = performance.now();
-    const { blob, pagesCount } = await preparePDF(pdfPages, hasMargin);
+    const context = createOperationContext();
+    const snapshot = lastProcessingSnapshotRef.current;
+    let failureStage: FailureStage = 'compose_pdf';
 
-    captureProductEvent(
-      'label_pdf_printed',
-      buildProcessingProperties(
-        pdfPages,
-        1,
-        pagesCount,
-        blob.size,
-        Math.round(performance.now() - startedAt),
-        'success'
-      )
-    );
+    try {
+      const { blob, pagesCount } = await runWorkflowStep(
+        'compose_pdf',
+        async () => await preparePDF(pdfPages, hasMargin)
+      );
+      const blobURL = URL.createObjectURL(blob);
 
-    const blobURL = URL.createObjectURL(blob);
+      failureStage = 'print_pdf';
+      const iframe = document.createElement('iframe');
+      iframe.style.display = 'none';
+      document.body.appendChild(iframe);
+      iframe.src = blobURL;
 
-    const iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
-    document.body.appendChild(iframe);
-    iframe.src = blobURL;
+      iframe.onload = function () {
+        setTimeout(function () {
+          iframe.contentWindow?.print();
+        }, 1);
+      };
 
-    iframe.onload = function () {
-      setTimeout(function () {
-        iframe.contentWindow?.print();
-      }, 1);
-    };
+      captureProductEvent(
+        'label_pdf_printed',
+        buildWorkflowProperties({
+          context,
+          durationMs: getOperationDurationMs(context),
+          labels: pdfPages,
+          operation: 'print_pdf',
+          outcome: 'success',
+          snapshot,
+          outputPagesCount: pagesCount,
+          outputSizeBytes: blob.size,
+        })
+      );
+    } catch (error) {
+      captureWorkflowFailure(
+        'label_pdf_print_failed',
+        buildWorkflowProperties({
+          context,
+          durationMs: getOperationDurationMs(context),
+          labels: pdfPages,
+          operation: 'print_pdf',
+          outcome: 'failure',
+          snapshot,
+          outputPagesCount: 0,
+          failureStage: getFailureStage(error, failureStage),
+          error,
+        }),
+        error
+      );
+    }
   };
 
   const handleFileDownload = async (hasMargin: boolean) => {
-    const startedAt = performance.now();
-    const { blob, pagesCount } = await preparePDF(pdfPages, hasMargin);
+    const context = createOperationContext();
+    const snapshot = lastProcessingSnapshotRef.current;
+    let failureStage: FailureStage = 'compose_pdf';
 
-    captureProductEvent(
-      'label_pdf_downloaded',
-      buildProcessingProperties(
-        pdfPages,
-        1,
-        pagesCount,
-        blob.size,
-        Math.round(performance.now() - startedAt),
-        'success'
-      )
-    );
+    try {
+      const { blob, pagesCount } = await runWorkflowStep(
+        'compose_pdf',
+        async () => await preparePDF(pdfPages, hasMargin)
+      );
 
-    saveAs(blob, `PostLabel - ${getCurrentDateTimeFormatted()}.pdf`);
+      failureStage = 'download_pdf';
+      saveAs(blob, `PostLabel - ${getCurrentDateTimeFormatted()}.pdf`);
+
+      captureProductEvent(
+        'label_pdf_downloaded',
+        buildWorkflowProperties({
+          context,
+          durationMs: getOperationDurationMs(context),
+          labels: pdfPages,
+          operation: 'download_pdf',
+          outcome: 'success',
+          snapshot,
+          outputPagesCount: pagesCount,
+          outputSizeBytes: blob.size,
+        })
+      );
+    } catch (error) {
+      captureWorkflowFailure(
+        'label_pdf_download_failed',
+        buildWorkflowProperties({
+          context,
+          durationMs: getOperationDurationMs(context),
+          labels: pdfPages,
+          operation: 'download_pdf',
+          outcome: 'failure',
+          snapshot,
+          outputPagesCount: 0,
+          failureStage: getFailureStage(error, failureStage),
+          error,
+        }),
+        error
+      );
+    }
   };
 
   return {

--- a/src/utils/pdf-util.ts
+++ b/src/utils/pdf-util.ts
@@ -181,13 +181,12 @@ function captureWorkflowFailure(
 
 function buildValidationSnapshot(
   files: File[],
-  rejectedFilesCount: number,
   payloadSizeBytes: number
 ): ProcessingSnapshot {
   return {
     filesCount: files.length,
     acceptedFilesCount: 0,
-    rejectedFilesCount,
+    rejectedFilesCount: files.length,
     inputPagesCount: 0,
     payloadSizeBytes,
   };
@@ -215,7 +214,7 @@ export function usePDFHandler() {
     const files = e.target.files ? Array.from(e.target.files) : [];
     const totalSize = files.reduce((total, file) => total + file.size, 0);
 
-    const captureValidationReject = (rejectReason: RejectReason, rejectedFilesCount: number) => {
+    const captureValidationReject = (rejectReason: RejectReason) => {
       captureProductEvent(
         'label_file_rejected',
         buildWorkflowProperties({
@@ -224,7 +223,7 @@ export function usePDFHandler() {
           labels: [],
           operation: 'validate_files',
           outcome: 'rejected',
-          snapshot: buildValidationSnapshot(files, rejectedFilesCount, totalSize),
+          snapshot: buildValidationSnapshot(files, totalSize),
           outputPagesCount: 0,
           rejectReason,
         })
@@ -233,14 +232,14 @@ export function usePDFHandler() {
 
     const nonPdfFiles = files.filter((file) => file.type !== 'application/pdf');
     if (nonPdfFiles.length > 0) {
-      captureValidationReject('non_pdf_file', nonPdfFiles.length);
+      captureValidationReject('non_pdf_file');
       alert('Some files were not uploaded because they are not PDFs.');
       setIsLoading(false);
       return;
     }
 
     if (files.length > 100) {
-      captureValidationReject('too_many_files', files.length);
+      captureValidationReject('too_many_files');
       alert('You cannot upload more than 100 files at once.');
       setIsLoading(false);
       return;
@@ -248,14 +247,14 @@ export function usePDFHandler() {
 
     const largeFiles = files.filter((file) => file.size > 1000000);
     if (largeFiles.length > 0) {
-      captureValidationReject('file_too_large', largeFiles.length);
+      captureValidationReject('file_too_large');
       alert('Some files were not uploaded because they exceed the 1MB size limit.');
       setIsLoading(false);
       return;
     }
 
     if (totalSize > 5000000) {
-      captureValidationReject('payload_too_large', files.length);
+      captureValidationReject('payload_too_large');
       alert('The total size of all files exceeds the 5MB limit.');
       setIsLoading(false);
       return;
@@ -268,7 +267,7 @@ export function usePDFHandler() {
     const payloadSizeBytes = validFiles.reduce((total, file) => total + file.size, 0);
 
     if (validFiles.length === 0) {
-      captureValidationReject('no_valid_files', files.length);
+      captureValidationReject('no_valid_files');
       clearPdfPages();
       setIsLoading(false);
       alert('There were no valid files selected.');


### PR DESCRIPTION
## Summary

- Standardizes PostHog product analytics around a new typed event schema with schema versioning, short-lived correlation IDs, normalized label-source counts, bucketed file sizes, and explicit success/failure/reject outcomes.
- Enables PostHog browser exception capture while preserving the privacy posture: no autocapture, no session replay, no user identification, and no PDF contents, filenames, addresses, labels, or tracking numbers in analytics.
- Refactors PDF processing, download, print, and validation flows to emit structured success/reject/failure events and paired handled exception telemetry for workflow errors.
- Updates legal copy, README, env typings, and `.env.example` to document browser error telemetry and optional public build metadata.
- Makes `pnpm lint` run both Oxlint and `tsc --noEmit`, and fixes the existing `pdfjs-dist` text-content typing issue.

## Verification

- `pnpm lint`
- `pnpm build`
- Validated recent local product events in PostHog MCP for schema version, correlation IDs, bucketed sizes, label-source counts, and privacy-sensitive omissions.