### PR TITLE
Remove-plausible-entirely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # PostHog product analytics (publishable browser key)
-# Events are sent via first-party /ingest proxy (see vercel.json)
+# Events are sent via first-party /plb proxy (see vercel.json)
 PUBLIC_POSTHOG_KEY=
 # Optional: PostHog app UI host for toolbar links (defaults to EU)
 # PUBLIC_POSTHOG_UI_HOST=https://eu.posthog.com

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want to run PostLabel on your own machine:
 1. Clone the repository.
 2. Install [pnpm](https://pnpm.io/) if needed.
 3. Run `pnpm install` from the root directory.
-4. Optionally copy `.env.example` to `.env` and set `PUBLIC_POSTHOG_KEY` for analytics (events are proxied via `/ingest` on your domain).
+4. Optionally copy `.env.example` to `.env` and set `PUBLIC_POSTHOG_KEY` for analytics (events are proxied via `/plb` on your domain).
 5. Run `pnpm dev` to start the development server.
 
 ## Environment Variables

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,20 +15,20 @@ export default defineConfig({
   vite: {
     server: {
       proxy: {
-        '/ingest/static': {
+        '/plb/static': {
           target: posthogAssetHost,
           changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/ingest/, ''),
+          rewrite: (path) => path.replace(/^\/plb/, ''),
         },
-        '/ingest/array': {
+        '/plb/array': {
           target: posthogAssetHost,
           changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/ingest/, ''),
+          rewrite: (path) => path.replace(/^\/plb/, ''),
         },
-        '/ingest': {
+        '/plb': {
           target: posthogApiHost,
           changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/ingest/, ''),
+          rewrite: (path) => path.replace(/^\/plb/, ''),
         },
       },
     },

--- a/src/components/about/AboutPage.tsx
+++ b/src/components/about/AboutPage.tsx
@@ -75,8 +75,8 @@ export default function AboutPage() {
               PostLabel does not store any PII outside of what GDPR and most regulators consider
               &quot;strictly necessary&quot;. PDF processing happens entirely in your browser. We
               collect aggregate product analytics (counts and sizes, never file contents) via
-              PostHog, plus cookieless infrastructure analytics from Cloudflare, Vercel, and
-              self-hosted Plausible. Go to <a href="/legal/tldr">Legal Section</a> for more details.
+              PostHog, plus cookieless infrastructure analytics from Cloudflare and Vercel. Go to{' '}
+              <a href="/legal/tldr">Legal Section</a> for more details.
             </p>
           </ExpandableSection>
 

--- a/src/components/analytics/PostHog.astro
+++ b/src/components/analytics/PostHog.astro
@@ -46,7 +46,7 @@ const posthogSnippet = posthogKey
     (e.__SV = 1));
 })(document, window.posthog || []);
 posthog.init(${JSON.stringify(posthogKey)}, {
-  api_host: '/ingest',
+  api_host: '/plb',
   ui_host: ${JSON.stringify(posthogUiHost)},
   autocapture: false,
   capture_pageview: true,

--- a/src/components/legal/DataPage.tsx
+++ b/src/components/legal/DataPage.tsx
@@ -20,8 +20,8 @@ export default function DataPage() {
 
       <h3 className="text-3xl">Third-Party Services</h3>
       <p>
-        The Service utilises cookie-less tracking providers including Cloudflare, Vercel, Plausible,
-        and PostHog for aggregate product and infrastructure analytics.
+        The Service utilises cookie-less tracking providers including Cloudflare, Vercel, and
+        PostHog for aggregate product and infrastructure analytics.
       </p>
       <p>
         For PDF processing, the Service utilises the{' '}
@@ -42,10 +42,6 @@ export default function DataPage() {
         Please refer to the privacy policies of{' '}
         <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noreferrer">
           Cloudflare
-        </a>
-        ,{' '}
-        <a href="https://plausible.io/data-policy" target="_blank" rel="noreferrer">
-          Plausible
         </a>
         ,{' '}
         <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noreferrer">

--- a/src/components/legal/PrivacyPage.tsx
+++ b/src/components/legal/PrivacyPage.tsx
@@ -17,14 +17,14 @@ export default function PrivacyPage() {
       <p>
         All PDF processing occurs client-side in your browser. No personally identifiable information
         (PII) from your PDFs is sent or stored on our servers. We collect aggregate product analytics
-        via PostHog and cookieless infrastructure analytics from Cloudflare, Vercel, and Plausible,
+        via PostHog and cookieless infrastructure analytics from Cloudflare and Vercel,
         as detailed in our <a href="/legal/data">Data Processing Agreement</a>.
       </p>
 
       <h3 className="text-3xl">Logging and Analytics</h3>
       <p>
-        The Service employs Cloudflare Cookieless Logging, Vercel Cookieless Analytics, Plausible
-        Cookieless Analytics, and PostHog product analytics. PostHog events are triggered during
+        The Service employs Cloudflare Cookieless Logging, Vercel Cookieless Analytics, and PostHog
+        product analytics. PostHog events are triggered during
         Processing, Downloading, and Printing. They contain only aggregate counts (files, pages,
         labels, label types), size buckets, timing, and page context — never filenames, label text,
         addresses, or tracking numbers. PostHog also receives browser error telemetry for debugging,
@@ -50,10 +50,6 @@ export default function PrivacyPage() {
         policies of{' '}
         <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noreferrer">
           Cloudflare
-        </a>
-        ,{' '}
-        <a href="https://plausible.io/data-policy" target="_blank" rel="noreferrer">
-          Plausible
         </a>
         ,{' '}
         <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noreferrer">

--- a/src/components/legal/TldrPage.tsx
+++ b/src/components/legal/TldrPage.tsx
@@ -49,11 +49,7 @@ export default function TldrPage() {
       <p>
         The app is hosted on Vercel (static, stateless) with DNS and reverse proxy managed by
         Cloudflare. Both collect cookieless infrastructure analytics that generalise and anonymise
-        request metadata.
-      </p>
-      <p>
-        There is also Plausible Community Edition, self-hosted in a datacenter in Germany,
-        Frankfurt.
+        request metadata. Product analytics are processed by PostHog Cloud (EU).
       </p>
       <p>
         Go to <a href="/legal/data">Data Processing Agreement</a> for more details.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,6 +43,5 @@ const ogImage = 'https://postlabel.neveroff.dev/landing-image-open-graph-01-comp
     <slot />
     <Footer />
     <PostHog />
-    <script defer data-domain="postlabel.neveroff.dev" src="https://plausible.devguild.ltd/js/script.js"></script>
   </body>
 </html>

--- a/vercel.json
+++ b/vercel.json
@@ -10,15 +10,15 @@
   "buildCommand": "pnpm build",
   "rewrites": [
     {
-      "source": "/ingest/static/:path(.*)",
+      "source": "/plb/static/:path(.*)",
       "destination": "https://eu-assets.i.posthog.com/static/:path"
     },
     {
-      "source": "/ingest/array/:path(.*)",
+      "source": "/plb/array/:path(.*)",
       "destination": "https://eu-assets.i.posthog.com/array/:path"
     },
     {
-      "source": "/ingest/:path(.*)",
+      "source": "/plb/:path(.*)",
       "destination": "https://eu.i.posthog.com/:path"
     }
   ]


### PR DESCRIPTION
## Summary

- Remove Plausible entirely: drop the script tag from `BaseLayout.astro` and all mentions across legal pages and the About FAQ.
- Rename the PostHog first-party proxy from `/ingest` to `/plb` in `PostHog.astro`, `vercel.json`, `astro.config.mjs`, and docs — avoids uBlock Privacy list rules that block `/ingest/*^ip=`.

## Test plan

- [ ] Deploy preview loads without requests to `plausible.devguild.ltd`
- [ ] PostHog events and `/plb/static/array.js` succeed with uBlock enabled
- [ ] Legal/About copy references PostHog, Cloudflare, and Vercel only