### PR TITLE
docs: add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,40 @@ If a security fix or dependency update appears blocked by `minimumReleaseAge`:
 3. **`minimumReleaseAgeExclude`** may only be added for a **named package/version** after **explicit confirmation from the repository owner**, and only when no other patched version is available within the age window.
 
 When in doubt, ask the owner before touching release-age settings.
+
+## Cursor Cloud specific instructions
+
+PostLabel is a single-package Astro 6 static site (React island for PDF processing). There is no database, Docker, or backend API.
+
+### Node.js version
+
+The repo requires **Node 24** (see `.nvmrc` and `package.json` `engines`). Cloud VMs may have `/exec-daemon/node` (v22) earlier on `PATH` than nvm — prepend Node 24 before running pnpm:
+
+```bash
+export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh"
+export PATH="$NVM_DIR/versions/node/$(cat .nvmrc).0/bin:$PATH"  # or pin v24.16.0
+```
+
+### Commands
+
+See `README.md` for the canonical list. Quick reference:
+
+| Task | Command |
+|------|---------|
+| Install deps | `pnpm install` |
+| Dev server | `pnpm dev` → http://localhost:4321 |
+| Lint | `pnpm lint` (oxlint + `tsc --noEmit`) |
+| Typecheck | `pnpm typecheck` (`astro check`) |
+| Build | `pnpm build` |
+| Preview prod build | `pnpm preview` |
+
+### Dev server
+
+- Start with `pnpm dev` (add `--host 0.0.0.0` if accessing from outside the VM).
+- Core workflow lives at `/print/` — upload Royal Mail / eBay / ParcelForce PDFs; processing is entirely client-side.
+- PostHog analytics (`PUBLIC_POSTHOG_KEY` in `.env`) is optional for local dev.
+
+### Known environment caveats
+
+- `astro check` can OOM on constrained VMs; use `NODE_OPTIONS="--max-old-space-size=8192"` if needed. `pnpm build` is the more reliable compile check.
+- `pnpm lint` runs `tsc --noEmit`, which may report `import.meta.env.MODE` typing separately from `astro build` (Astro injects `MODE` at build time).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting:

- Node 24 requirement and PATH workaround for Cloud VMs
- Standard pnpm commands for dev/lint/build
- Dev server access and `/print/` workflow
- Known caveats (`astro check` OOM, `import.meta.env.MODE` tsc vs build)

Part of Cloud Agent development environment setup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93f768de-aeb3-43cd-9b00-6bf7d15cc63b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93f768de-aeb3-43cd-9b00-6bf7d15cc63b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

